### PR TITLE
Added an example of starting the configuration portal when a double reset is detected.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
 # install lib arduino json not working in 1.6.5
 #  - arduino --install-library "ArduinoJson"
   - git clone https://github.com/bblanchon/ArduinoJson /usr/local/share/arduino/libraries/ArduinoJson
+  - git clone https://github.com/datacute/DoubleResetDetector /usr/local/share/arduino/libraries/DoubleResetDetector
   - arduino --install-boards esp8266:esp8266
   - arduino --board esp8266:esp8266:generic --save-prefs
   - arduino --pref "compiler.warning_level=all" --save-prefs

--- a/examples/ConfigOnDoubleReset/ConfigOnDoubleReset.ino
+++ b/examples/ConfigOnDoubleReset/ConfigOnDoubleReset.ino
@@ -1,0 +1,104 @@
+/*
+This example will open a configuration portal for 60 seconds when first powered up.
+ConfigOnSwitch is a a bettter example for most situations but this has the advantage 
+that no pins or buttons are required on the ESP8266 device at the cost of delaying 
+the user sketch for the period that the configuration portal is open.
+
+Also in this example a password is required to connect to the configuration portal 
+network. This is inconvenient but means that only those who know the password or those 
+already connected to the target WiFi network can access the configuration portal and 
+the WiFi network credentials will be sent from the browser over an encrypted connection and
+can not be read by observers.
+*/
+#include <ESP8266WiFi.h>          //https://github.com/esp8266/Arduino
+
+//needed for library
+#include <ESP8266WebServer.h>
+#include <DNSServer.h>
+#include <WiFiManager.h>          //https://github.com/kentaylor/WiFiManager
+
+#include <DoubleResetDetector.h>  //https://github.com/datacute/DoubleResetDetector
+
+// Number of seconds after reset during which a 
+// subseqent reset will be considered a double reset.
+#define DRD_TIMEOUT 10
+
+// RTC Memory Address for the DoubleResetDetector to use
+#define DRD_ADDRESS 0
+
+DoubleResetDetector drd(DRD_TIMEOUT, DRD_ADDRESS);
+
+// Onboard LED I/O pin on NodeMCU board
+const int PIN_LED = 2; // D4 on NodeMCU and WeMos. Controls the onboard LED.
+
+// Indicates whether ESP has WiFi credentials saved from previous session, or double reset detected
+bool initialConfig = false;
+
+void setup() {
+  // put your setup code here, to run once:
+  // initialize the LED digital pin as an output.
+  pinMode(PIN_LED, OUTPUT);
+  Serial.begin(115200);
+  Serial.println("\n Starting");
+  WiFi.printDiag(Serial); //Remove this line if you do not want to see WiFi password printed
+  if (WiFi.SSID()==""){
+    Serial.println("We haven't got any access point credentials, so get them now");   
+    initialConfig = true;
+  }
+  if (drd.detectDoubleReset()) {
+    Serial.println("Double Reset Detected");
+    initialConfig = true;
+  }
+  if (initialConfig) {
+    Serial.println("Starting configuration portal.");
+    digitalWrite(PIN_LED, LOW); // turn the LED on by making the voltage LOW to tell us we are in configuration mode.
+    //Local intialization. Once its business is done, there is no need to keep it around
+    WiFiManager wifiManager;
+
+    //sets timeout in seconds until configuration portal gets turned off.
+    //If not specified device will remain in configuration mode until
+    //switched off via webserver or device is restarted.
+    //wifiManager.setConfigPortalTimeout(600);
+
+    //it starts an access point 
+    //and goes into a blocking loop awaiting configuration
+    if (!wifiManager.startConfigPortal("ESP8266","password")) {//Delete these two parameters if you do not want a WiFi password on your configuration access point
+      Serial.println("Not connected to WiFi but continuing anyway.");
+    } else {
+      //if you get here you have connected to the WiFi
+      Serial.println("connected...yeey :)");
+    }
+    digitalWrite(PIN_LED, HIGH); // Turn led off as we are not in configuration mode.
+    ESP.reset(); // This is a bit crude. For some unknown reason webserver can only be started once per boot up 
+    // so resetting the device allows to go back into config mode again when it reboots.
+    delay(5000);
+  }
+
+  digitalWrite(PIN_LED, HIGH); // Turn led off as we are not in configuration mode.
+  WiFi.mode(WIFI_STA); // Force to station mode because if device was switched off while in access point mode it will start up next time in access point mode.
+  unsigned long startedAt = millis();
+  Serial.print("After waiting ");
+  int connRes = WiFi.waitForConnectResult();
+  float waited = (millis()- startedAt);
+  Serial.print(waited/1000);
+  Serial.print(" secs in setup() connection result is ");
+  Serial.println(connRes);
+  if (WiFi.status()!=WL_CONNECTED){
+    Serial.println("failed to connect, finishing setup anyway");
+  } else{
+    Serial.print("local ip: ");
+    Serial.println(WiFi.localIP());
+  }
+}
+
+
+void loop() {
+  // Call the double reset detector loop method every so often,
+  // so that it can recognise when the timeout expires.
+  // You can also call drd.stop() when you wish to no longer
+  // consider the next reset as a double reset.
+  drd.loop();
+
+  // put your main code here, to run repeatedly:
+  
+}


### PR DESCRIPTION
I've rewritten the my double reset detector to use RTC User Memory, and created this example based on the ConfigOnStartup and ConfigOnSwitch examples.
